### PR TITLE
feat: health-rollup grade (A–F · 0–100) + F8 diff-chain emission

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,9 @@ jobs:
         with:
           fetch-depth: 50
 
+      # pnpm version comes from package.json "packageManager" (pnpm@11.3.0).
+      # Do NOT also set `version:` here — action-setup@v4 errors on a dual spec.
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,14 +40,19 @@ jobs:
       - name: Smoke — analyze self
         shell: bash
         run: |
-          ./apps/cli/node_modules/.bin/tsx apps/cli/src/cli.ts analyze . --json > /tmp/smoke.json
+          # cwd-relative path, not /tmp: bash's `> /tmp/x` and Node's
+          # readFileSync('/tmp/x') disagree on the Windows runner (Node maps
+          # /tmp to D:\tmp → ENOENT). A relative file resolves identically for
+          # both. Cleaned up after so no later tree-clean step sees it.
+          ./apps/cli/node_modules/.bin/tsx apps/cli/src/cli.ts analyze . --json > smoke.json
           node -e "
-            const j = JSON.parse(require('fs').readFileSync('/tmp/smoke.json','utf8'));
+            const j = JSON.parse(require('fs').readFileSync('smoke.json','utf8'));
             if (!j.ok) throw new Error('analyze failed');
             if (!j.stats || j.stats.fileCount < 10) throw new Error('fileCount too low: ' + j.stats?.fileCount);
             if (typeof j.agentPath !== 'string') throw new Error('agentPath missing');
             console.log('[smoke] files=' + j.stats.fileCount + ' loc=' + j.stats.loc + ' risks=' + j.risks);
           "
+          rm -f smoke.json
 
       # Determinism gate (F13): re-run the benchmark over the committed corpus and
       # fail if the byte output drifts from bench/expected.json. Runs on every OS in

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -169,6 +169,21 @@ renders them to the `agent.diff.pack` wire form; `applyChain(master,
 diffs[])` reconstructs the row set (content, not order). Defined in
 `packages/factspack/src/chain.ts` + `encode.ts`; INV1-pure.
 
+### `sync_pack` (MCP tool — the F8 consumer)
+The reader half of the diff-chain. An agent passes `have` (the 12-hex
+sha256 of the master it currently holds) and gets back the smallest
+correct response as a JSON envelope `{ status, sha, pack? }`:
+`current` (you are up to date — no pack), `diff` (pack is the small
+delta; apply it onto your held master), or `full` (pack is the whole
+master — adopt it). `sha` is the current master's sha — pass it back as
+`have` next time. The branch logic is the pure `resolveSyncPack`
+(`apps/mcp-server/src/sync-pack.ts`), extracted from the server handler
+so it is unit-testable without the stdio transport; the handler reads
+`.facts/agent.pack` + `agent.diff.pack` and delegates. Input schema:
+`SyncPackInputSchema` in `@factstack/spec`. Turns the producer's on-disk
+`agent.diff.pack` into an end-to-end token win (≈2% of the master for a
+one-step-behind caller).
+
 ---
 
 ## Security tier — vocabulary introduced 2026-05-27

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -126,6 +126,49 @@ Thin top-level export from `packages/emit-browser/`. Constructs an
 permission), calls `writeArtifactsTo`. Backward-compatible surface
 for the in-browser scan flow.
 
+## F8 diff-chain — vocabulary introduced 2026-06-16
+
+### `agent.diff.pack`
+The incremental sidecar artifact. When a previous `agent.pack` exists,
+`writeArtifactsTo` additionally writes this: the row-level delta from
+that prior master to the new one. It is a **best-effort accelerator,
+not a canonical artifact** — `agent.pack` stays a full, self-contained
+master that every existing consumer reads directly. A consumer that
+already holds the prior master applies this small diff instead of
+re-reading the whole pack. Absent on the first run; lives under
+`.facts/` (gitignored), so it never enters commits or determinism
+checks. The win scales with the *kind* of change: a pure content edit
+is tiny (~2% of the master), but adding/removing files ripples PageRank
+`importance` across the `nodeMetrics`/`top` rows, so structural change
+diffs are larger (~27% dogfooded on FACTS itself).
+
+### diff-chain (depth-1)
+The design: each diff applies onto the **immediately preceding master**,
+never onto another diff. So a consumer applies at most one diff to reach
+current state, and there is no growing chain, no manifest, and no
+compaction step. The diff header carries `kind='diff'`,
+`seq=(prev.seq ?? 1)+1`, and `parent=prev.trailer.sha256` (the 12-hex
+the encoder already stamped on the master), which the consumer verifies
+before applying — a mismatch means "stale master, read the full pack."
+
+### `prevPackBody` (orchestrator option)
+The shim-threaded prior master. The `FileWriter` interface was
+deliberately **not** given a `readText` method; instead each shim
+(`writeArtifacts` Node, `writeBrowserArtifacts` browser) pre-reads
+`.facts/agent.pack` before it is overwritten and passes the body in via
+this option. The orchestrator stays write-only and isomorphic. The diff
+emission is wrapped in try/catch and only fires when the prior pack
+decodes, carries a trailer, and shares the new master's schema — any
+failure skips the diff and leaves the master authoritative.
+
+### `computeDiff` / `applyChain` / `encodeIncremental` (factspack)
+The pure isomorphic primitives the orchestrator composes.
+`computeDiff(prevDecoded, nextDecoded)` returns the per-table
+added/deleted rows (omitting unchanged tables); `encodeIncremental`
+renders them to the `agent.diff.pack` wire form; `applyChain(master,
+diffs[])` reconstructs the row set (content, not order). Defined in
+`packages/factspack/src/chain.ts` + `encode.ts`; INV1-pure.
+
 ---
 
 ## Security tier — vocabulary introduced 2026-05-27

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -36,6 +36,7 @@ import {
   buildContextStore,
   buildDiagram,
   buildMemory,
+  computeHealth,
   contextRecordEvent,
   diffArtifacts,
   executeQuery,
@@ -299,7 +300,7 @@ program
           }
         : undefined,
     });
-    restoreVulnScan(root, result.agent); // v0.11 — a re-analyze must not wipe the last CVE scan
+    restoreVulnScan(root, result.agent, result.human); // v0.11 carry CVEs + v0.3 re-grade health
 
     /* F8 — snapshot cache hit/miss for the report, then close the db. `hits` =
        files served from cache.db (unchanged content) without re-parsing;
@@ -446,7 +447,7 @@ program
       );
       const fs = nodeFS(root);
       const result = await analyze(fs, { root: '.', projectName: path.basename(root), gzip: gzippedBytes, gitStats: mineGitStats(root) });
-      restoreVulnScan(root, result.agent); // v0.11 — a re-analyze must not wipe the last CVE scan
+      restoreVulnScan(root, result.agent, result.human); // v0.11 carry CVEs + v0.3 re-grade health
       await writeArtifacts({ root, agent: result.agent, human: result.human, addGitignoreEntry: true, memoryBody: buildMemory(result.agent, result.human, { contextStore: loadContextStore(root) }) });
     }
 
@@ -510,7 +511,7 @@ program
       resetIdle();
       const fs = nodeFS(root);
       const result = await analyze(fs, { root: '.', projectName: path.basename(root), gzip: gzippedBytes, gitStats: mineGitStats(root) });
-      restoreVulnScan(root, result.agent); // v0.11 — a re-analyze must not wipe the last CVE scan
+      restoreVulnScan(root, result.agent, result.human); // v0.11 carry CVEs + v0.3 re-grade health
       await writeArtifacts({ root, agent: result.agent, human: result.human, addGitignoreEntry: true, writeSnapshot: true, memoryBody: buildMemory(result.agent, result.human, { contextStore: loadContextStore(root) }) });
       const fresh = humanToViz(result.agent, result.human);
       fresh.project.root = root;
@@ -1059,7 +1060,7 @@ program
       process.stderr.write(kleur.dim('  no existing .facts/ — analyzing first…\n'));
       const fs = nodeFS(root);
       const result = await analyze(fs, { root: '.', projectName: path.basename(root), gzip: gzippedBytes, gitStats: mineGitStats(root) });
-      restoreVulnScan(root, result.agent); // v0.11 — a re-analyze must not wipe the last CVE scan
+      restoreVulnScan(root, result.agent, result.human); // v0.11 carry CVEs + v0.3 re-grade health
       await writeArtifacts({ root, agent: result.agent, human: result.human, addGitignoreEntry: true, memoryBody: buildMemory(result.agent, result.human, { contextStore: loadContextStore(root) }) });
     }
 
@@ -1170,7 +1171,7 @@ program
       process.stderr.write(kleur.dim('  scanning ') + kleur.reset(path.basename(root)) + kleur.dim('…\n'));
       const fs = nodeFS(root);
       const result = await analyze(fs, { root: '.', projectName: path.basename(root), gzip: gzippedBytes, gitStats: mineGitStats(root) });
-      restoreVulnScan(root, result.agent); // v0.11 — a re-analyze must not wipe the last CVE scan
+      restoreVulnScan(root, result.agent, result.human); // v0.11 carry CVEs + v0.3 re-grade health
       await writeArtifacts({ root, agent: result.agent, human: result.human, addGitignoreEntry: true, memoryBody: buildMemory(result.agent, result.human, { contextStore: loadContextStore(root) }) });
     }
 
@@ -1450,6 +1451,9 @@ program
         findings: vulnerabilities.length,
       },
     };
+    /* v0.3 — re-grade health now that fresh CVEs are on the agent, so the
+       score/headline reflects the scan in both human.json and MEMORY.md. */
+    human.summary.health = computeHealth(nextAgent);
     await writeArtifacts({
       root,
       agent: nextAgent,
@@ -3169,22 +3173,28 @@ function loadContextStore(root: string): ContextStore {
  * kept from the original scan — carrying forward never makes data look
  * fresher than it is. Best-effort: no/unreadable prior artifact just means
  * nothing to carry. */
-function restoreVulnScan(root: string, agent: AgentArtifact): void {
+function restoreVulnScan(root: string, agent: AgentArtifact, human?: HumanArtifact): void {
   try {
     const p = path.join(root, '.facts', 'agent.json');
-    if (!existsSync(p)) return;
-    /* Raw parse, not loadAndValidate: the prior artifact may predate the
-       current schema; we only need two additive fields. */
-    const prev = JSON.parse(readFileSync(p, 'utf8')) as Partial<AgentArtifact>;
-    if (!prev.vulnerabilityScan) return; // never scanned — nothing to carry
-    agent.vulnerabilities = reconcileVulnerabilities(prev.vulnerabilities ?? [], agent.dependencyManifests);
-    /* `findings` is the spec's scanned-and-clean marker and must mirror the
-       (now reconciled) vulnerabilities array — copying the prior scan verbatim
-       would leave a stale count contradicting agent.vulnerabilities.length when
-       reconcile drops a removed/upgraded dep. scannedAt/packagesQueried stay as
-       the original scan event's metadata. */
-    agent.vulnerabilityScan = { ...prev.vulnerabilityScan, findings: agent.vulnerabilities.length };
+    if (existsSync(p)) {
+      /* Raw parse, not loadAndValidate: the prior artifact may predate the
+         current schema; we only need two additive fields. */
+      const prev = JSON.parse(readFileSync(p, 'utf8')) as Partial<AgentArtifact>;
+      if (prev.vulnerabilityScan) {
+        agent.vulnerabilities = reconcileVulnerabilities(prev.vulnerabilities ?? [], agent.dependencyManifests);
+        /* `findings` is the spec's scanned-and-clean marker and must mirror the
+           (now reconciled) vulnerabilities array — copying the prior scan verbatim
+           would leave a stale count contradicting agent.vulnerabilities.length when
+           reconcile drops a removed/upgraded dep. scannedAt/packagesQueried stay as
+           the original scan event's metadata. */
+        agent.vulnerabilityScan = { ...prev.vulnerabilityScan, findings: agent.vulnerabilities.length };
+      }
+    }
   } catch { /* unreadable prior artifact — start clean; scan-vulns rebuilds */ }
+  /* v0.3 — re-grade health AFTER the CVE carry-forward so vulnerabilities land
+     in the score/headline (analyze() grades before this restore runs). Idempotent
+     when there are no vulns; `human` is threaded from every artifact-write path. */
+  if (human) human.summary.health = computeHealth(agent);
 }
 
 /** Age of an ISO timestamp in whole days (floored, never negative). */

--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -20,6 +20,8 @@
  *     log_learning          — append a proposal/outcome to learnings.jsonl (v0.3.4)
  *     query_learnings       — filter the learnings log (v0.3.4)
  *     get_config            — env-var inventory + read sites (v0.3.6)
+ *     sync_pack             — fetch agent.pack as a small diff when the caller
+ *                             already holds the prior master (F8 consumer)
  *
  * Designed for agent consumption: every resource returns JSON matching
  * the Zod schemas in `@factstack/spec` so tools can validate.
@@ -78,6 +80,7 @@ import {
 } from './pack-responses.js';
 import { gzippedBytes, writeArtifacts } from '@factstack/emit';
 import { mineGitStats, nodeFS } from '@factstack/fs-node';
+import { resolveSyncPack } from './sync-pack.js';
 import {
   approximateTokens,
   flattenManifests,
@@ -97,6 +100,7 @@ import {
   QueryInputSchema,
   CountTokensInputSchema,
   ContextInputSchema,
+  SyncPackInputSchema,
   jsonSchemaByKind,
   MCP_TOOL,
   type AgentArtifact,
@@ -507,6 +511,19 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
           format: { type: 'string', enum: ['pack', 'json'], description: 'Response shape (default pack).', default: 'pack' },
         },
         required: ['query'],
+      },
+    },
+    {
+      name: MCP_TOOL.sync_pack,
+      description: 'F8 — fetch the current agent.pack as a SMALL DIFF when you already hold the previous master, instead of re-reading the whole pack. Pass `have` = the 12-hex sha256 from the trailer of the pack you last received (omit on first fetch). JSON envelope: `{ status, sha, pack? }`. status="current" (you are up to date; no pack), "diff" (pack is the row-level delta — read the + added / x removed rows and apply them onto your held master), or "full" (pack is the complete master — adopt it). `sha` is the current master sha; pass it back as `have` next time. Reads the cached analysis (call `analyze` first to refresh against changed code).',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          have: {
+            type: 'string',
+            description: 'The 12-hex sha256 of the agent.pack master you currently hold (from a prior sync_pack `sha` / the pack trailer). Omit on first fetch.',
+          },
+        },
       },
     },
   ],
@@ -1002,6 +1019,44 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
       return { content: [{ type: 'text', text: contextToPack(result, snapshotId) }] };
     }
     return { content: [{ type: 'text', text: JSON.stringify(result) }] };
+  }
+
+  if (name === MCP_TOOL.sync_pack) {
+    if (!cached) await ensureAnalyzed();
+    const parsed = SyncPackInputSchema.safeParse(args);
+    if (!parsed.success) {
+      const issues = parsed.error.issues.map((i) => ({ field: i.path.join('.') || '(root)', message: i.message }));
+      return {
+        content: [{ type: 'text', text: JSON.stringify({ status: 'error', error: 'invalid sync_pack input', issues }) }],
+        isError: true,
+      };
+    }
+    const have = parsed.data.have;
+    const masterPath = path.join(root, '.facts', 'agent.pack');
+    const diffPath = path.join(root, '.facts', 'agent.diff.pack');
+
+    // The on-disk master IS the current pack — analyze() writes it in lockstep
+    // with cached.agent. Read it + the diff sidecar (best-effort) and let the
+    // pure resolver decide current/diff/full.
+    let masterBody: string;
+    try {
+      masterBody = readFileSync(masterPath, 'utf8');
+    } catch {
+      return {
+        content: [{ type: 'text', text: JSON.stringify({ status: 'error', error: 'no readable agent.pack — run analyze first' }) }],
+        isError: true,
+      };
+    }
+    let diffBody: string | undefined;
+    if (existsSync(diffPath)) {
+      try { diffBody = readFileSync(diffPath, 'utf8'); } catch { diffBody = undefined; }
+    }
+
+    const result = resolveSyncPack(masterBody, diffBody, have);
+    return {
+      content: [{ type: 'text', text: JSON.stringify(result) }],
+      ...(result.status === 'error' ? { isError: true } : {}),
+    };
   }
 
   throw new Error(`Unknown tool: ${name}`);

--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -47,6 +47,7 @@ import {
   buildChangeVerdict,
   buildContextStore,
   buildMemory,
+  computeHealth,
   buildDiagram,
   lastServedEntities,
   recentSessionEntities,
@@ -131,6 +132,9 @@ async function runAnalyze(): Promise<AgentArtifact['stats']> {
   // v0.11 — a re-analyze must not wipe the last CVE scan (analyze itself is
   // network-free per INV6 and returns an empty list). Mirrors the CLI.
   restoreVulnScanInto(result.agent);
+  // v0.3 — re-grade health after the CVE carry-forward so vulnerabilities land
+  // in the score/headline (analyze() grades before the restore). Mirrors the CLI.
+  result.human.summary.health = computeHealth(result.agent);
   // F9 — fold the durable context store (decisions / open tasks / questions
   // recorded in learnings.jsonl) into MEMORY.md's "Working context" section.
   const memoryBody = buildMemory(result.agent, result.human, {
@@ -772,9 +776,19 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
             findings: vulnerabilities.length,
           },
         };
-        const memoryBody = buildMemory(nextAgent, cached!.human, { contextStore: buildContextStore(readLearnings()) });
-        await writeArtifacts({ root, agent: nextAgent, human: cached!.human, addGitignoreEntry: false, memoryBody });
-        cached = { agent: nextAgent, human: cached!.human, memory: memoryBody };
+        // v0.3 — re-grade health so the freshly-fetched CVEs land in the
+        // score/headline written to human.json + MEMORY.md. Build the updated
+        // human immutably and only swap `cached` AFTER the write succeeds — a
+        // failed write must leave the in-memory cache consistent (old agent +
+        // old health together), matching the catch block's "stale data stays
+        // untouched" promise.
+        const updatedHuman: HumanArtifact = {
+          ...cached!.human,
+          summary: { ...cached!.human.summary, health: computeHealth(nextAgent) },
+        };
+        const memoryBody = buildMemory(nextAgent, updatedHuman, { contextStore: buildContextStore(readLearnings()) });
+        await writeArtifacts({ root, agent: nextAgent, human: updatedHuman, addGitignoreEntry: false, memoryBody });
+        cached = { agent: nextAgent, human: updatedHuman, memory: memoryBody };
       } catch (err) {
         /* A failed refresh must NEVER look like a successful empty scan —
            return an explicit error; the stale data stays untouched on disk. */

--- a/apps/mcp-server/src/sync-pack.ts
+++ b/apps/mcp-server/src/sync-pack.ts
@@ -1,0 +1,67 @@
+/**
+ * F8 consumer — the pure decision behind the `sync_pack` MCP tool.
+ *
+ * Given the on-disk master (`agent.pack`), the optional diff sidecar
+ * (`agent.diff.pack`), and the sha256 the caller currently holds, decide the
+ * smallest correct response:
+ *
+ *   - `current` — the caller already holds the current master. Send nothing.
+ *   - `diff`    — the caller holds the diff's parent (one step behind). Send the
+ *                 small delta; the caller reads the + added / x removed rows.
+ *   - `full`    — first fetch, stale, or unknown master. Send the whole master.
+ *
+ * Extracted from the server handler so the branch logic is unit-testable
+ * without the stdio transport. Pure: it only decodes the bytes it's handed.
+ */
+import { decode } from '@factstack/factspack';
+
+export interface SyncPackResult {
+  status: 'current' | 'diff' | 'full' | 'error';
+  /** The current master's 12-hex sha256 — the caller passes this back as
+   *  `have` next time. Absent only on `error`. */
+  sha?: string;
+  /** The pack text to read: the diff (status `diff`) or the master (`full`).
+   *  Absent on `current` (nothing to send) and `error`. */
+  pack?: string;
+  /** Present only on `error`. */
+  error?: string;
+}
+
+export function resolveSyncPack(
+  masterBody: string,
+  diffBody: string | undefined,
+  have: string | undefined,
+): SyncPackResult {
+  // The master's trailer sha is the chain anchor. Strict decode (the default)
+  // REQUIRES + verifies the integrity trailer, so a trailerless / truncated /
+  // corrupt master throws here and is caught below; on success the trailer is
+  // guaranteed present.
+  let currentSha: string;
+  try {
+    currentSha = decode(masterBody).trailer!.sha256;
+  } catch {
+    return { status: 'error', error: 'unreadable or trailerless master pack' };
+  }
+
+  // Already current — nothing to send but the confirmation + the sha held.
+  if (have && have === currentSha) {
+    return { status: 'current', sha: currentSha };
+  }
+
+  // One step behind — return the diff only when it bridges the caller's held
+  // master to the current one (its parent == what they hold). Best-effort: an
+  // unreadable or non-bridging diff falls through to the full master.
+  if (have && diffBody) {
+    try {
+      const d = decode(diffBody);
+      if (d.header.kind === 'diff' && d.header.parent === have) {
+        return { status: 'diff', sha: currentSha, pack: diffBody };
+      }
+    } catch {
+      /* unreadable diff → fall through to the full master */
+    }
+  }
+
+  // First fetch, stale, or unknown master — send the full master.
+  return { status: 'full', sha: currentSha, pack: masterBody };
+}

--- a/apps/mcp-server/test/sync-pack.test.ts
+++ b/apps/mcp-server/test/sync-pack.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Tests for `resolveSyncPack` — the F8 consumer's current/diff/full decision.
+ *
+ * Builds real master + diff packs via the factspack primitives (same idiom as
+ * factspack/test/chain.test.ts) and asserts the smallest-correct response for
+ * each caller state, plus the round-trip that proves the returned diff actually
+ * reconstructs the current master.
+ */
+import { describe, expect, it } from 'vitest';
+import { applyChain, computeDiff, decode, encode, encodeIncremental, type PackHeader, type PackRow } from '@factstack/factspack';
+import { resolveSyncPack } from '../src/sync-pack.js';
+
+const HEADER: PackHeader = {
+  producer: 'factstack/test',
+  schema: 'agent-v4',
+  snapshotId: 's',
+  rowCount: null,
+  seq: 1,
+  parent: '-',
+  kind: 'master',
+  generated: 'g',
+};
+
+function master(rows: PackRow[]): string {
+  return encode({ header: HEADER, tables: [{ name: 'files', columns: [{ name: 'path' }, { name: 'loc' }], rows }] });
+}
+
+const m1 = master([['a.ts', '1'], ['b.ts', '2']]);
+const sha1 = decode(m1).trailer!.sha256;
+const m2 = master([['a.ts', '1'], ['b.ts', '9'], ['c.ts', '3']]); // b changed, c added
+const sha2 = decode(m2).trailer!.sha256;
+const diff = encodeIncremental({
+  header: { ...HEADER, snapshotId: 's2', rowCount: 0, seq: 2, parent: sha1, kind: 'diff' },
+  tables: computeDiff(decode(m1), decode(m2)),
+});
+
+describe('resolveSyncPack — current / diff / full decision', () => {
+  it('status=current when the caller already holds the current master', () => {
+    const r = resolveSyncPack(m2, diff, sha2);
+    expect(r.status).toBe('current');
+    expect(r.sha).toBe(sha2);
+    expect(r.pack).toBeUndefined();
+  });
+
+  it('status=diff when the caller holds the diff parent (one step behind)', () => {
+    const r = resolveSyncPack(m2, diff, sha1);
+    expect(r.status).toBe('diff');
+    expect(r.sha).toBe(sha2);
+    expect(r.pack).toBe(diff);
+  });
+
+  it('status=full on first fetch (no have)', () => {
+    const r = resolveSyncPack(m2, diff, undefined);
+    expect(r.status).toBe('full');
+    expect(r.sha).toBe(sha2);
+    expect(r.pack).toBe(m2);
+  });
+
+  it('status=full when have is an unknown / stale sha', () => {
+    const r = resolveSyncPack(m2, diff, 'deadbeefcafe');
+    expect(r.status).toBe('full');
+    expect(r.pack).toBe(m2);
+  });
+
+  it('status=full when no diff sidecar exists (cold producer)', () => {
+    const r = resolveSyncPack(m2, undefined, sha1);
+    expect(r.status).toBe('full');
+    expect(r.pack).toBe(m2);
+  });
+
+  it('falls through to full when the diff does not bridge the held master', () => {
+    const otherParentDiff = encodeIncremental({
+      header: { ...HEADER, snapshotId: 's2', rowCount: 0, seq: 2, parent: 'ffffffffffff', kind: 'diff' },
+      tables: computeDiff(decode(m1), decode(m2)),
+    });
+    const r = resolveSyncPack(m2, otherParentDiff, sha1);
+    expect(r.status).toBe('full');
+  });
+
+  it('falls through to full when the diff body is corrupt/unreadable', () => {
+    // A bad diff sidecar must degrade gracefully to the full master, never error.
+    const r = resolveSyncPack(m2, 'this is not a valid pack', sha1);
+    expect(r.status).toBe('full');
+    expect(r.pack).toBe(m2);
+  });
+
+  it('status=error on an unreadable master', () => {
+    const r = resolveSyncPack('not a pack at all', diff, sha1);
+    expect(r.status).toBe('error');
+    expect(r.pack).toBeUndefined();
+    expect(r.sha).toBeUndefined();
+  });
+
+  it('round-trip: applying the returned diff onto the held master reproduces the current master', () => {
+    const r = resolveSyncPack(m2, diff, sha1);
+    expect(r.status).toBe('diff');
+    const rebuilt = applyChain(decode(m1), [decode(r.pack!)]);
+    const fresh = decode(m2);
+    const asSet = (rows: readonly PackRow[]) => rows.map((x) => JSON.stringify(x)).sort();
+    expect(asSet(rebuilt.get('files')!.rows)).toEqual(asSet(fresh.tables.get('files')!.rows));
+  });
+});

--- a/apps/ui-remix/src/lib/healthTone.ts
+++ b/apps/ui-remix/src/lib/healthTone.ts
@@ -1,0 +1,38 @@
+/**
+ * Canonical Overview health tone — one source of truth for "is this
+ * green/amber/red?" shared by the lede banner and the margin HealthGrade
+ * marque so the two surfaces never disagree.
+ *
+ * Prefers the v0.3 composite grade; falls back to the flat counts for
+ * pre-v0.3 baked datasets that carry no letter.
+ *
+ * Secrets and broken imports force `danger` regardless of the letter.
+ * A leaked secret is always act-now even if a single occurrence only
+ * nicks the score to a C — the grade is a summary, the tone is an alarm.
+ */
+import type { Dataset } from './loadArtifacts.ts';
+
+export type HealthTone = 'ok' | 'warn' | 'danger';
+
+/** Tone → design-token color. Co-located with the tone logic so the
+ *  marque's grade letter + deduction bars tint from the same source the
+ *  tone decision uses. (FootnoteChip keeps its own 5-tone map for chrome;
+ *  this is the 3-tone health subset the marque needs as a raw value.) */
+export const HEALTH_TONE_COLOR: Record<HealthTone, string> = {
+  ok: 'var(--ok)',
+  warn: 'var(--warn)',
+  danger: 'var(--danger)',
+};
+
+type Health = Dataset['summary']['health'];
+
+export function healthTone(h: Health): HealthTone {
+  if (h.secrets > 0 || h.broken > 0) return 'danger';
+  if (h.grade) {
+    if (h.grade === 'F') return 'danger';
+    if (h.grade === 'C' || h.grade === 'D') return 'warn';
+    return 'ok'; // A, B
+  }
+  // pre-grade dataset: secrets/broken already handled above.
+  return h.stale > 0 || h.todos > 0 ? 'warn' : 'ok';
+}

--- a/apps/ui-remix/src/lib/loadArtifacts.ts
+++ b/apps/ui-remix/src/lib/loadArtifacts.ts
@@ -61,7 +61,22 @@ export interface Dataset {
     oneLiner: string;
     description: string;
     capabilities: Array<{ icon: string; head: string; sub: string }>;
-    health: { broken: number; stale: number; todos: number; secrets: number };
+    health: {
+      broken: number;
+      stale: number;
+      todos: number;
+      secrets: number;
+      /** Prose summary — required since the original schema (e.g.
+       *  "B · 84 — 2 secrets exposed, 9 import cycles"). */
+      headline: string;
+      /** v0.3 — composite grade. `score` 0–100, `grade` its letter (A–F),
+       *  `factors` the top deductions ({label,count,penalty}). All optional
+       *  for backward-compat with pre-v0.3 baked datasets — the Health card
+       *  falls back to the flat counts when the grade is absent. */
+      score?: number;
+      grade?: 'A' | 'B' | 'C' | 'D' | 'F';
+      factors?: Array<{ label: string; count: number; penalty: number }>;
+    };
   };
   stats: { files: number; loc: number; size: number; gzip: number; tokens: number };
   tree: DatasetTreeNode;

--- a/apps/ui-remix/src/routes/Overview.tsx
+++ b/apps/ui-remix/src/routes/Overview.tsx
@@ -27,6 +27,8 @@ import { Section } from '../ui/Section.tsx';
 import { LabelNumber, LabelNumberRow } from '../ui/LabelNumber.tsx';
 import { ContentWithMargin, MarginColumn } from '../ui/MarginColumn.tsx';
 import { FootnoteChip } from '../ui/FootnoteChip.tsx';
+import { HealthGrade } from '../ui/HealthGrade.tsx';
+import { healthTone } from '../lib/healthTone.ts';
 import { TokenRoiPanel } from '../ui/TokenRoiPanel.tsx';
 
 interface OverviewProps {
@@ -276,41 +278,63 @@ export function Overview(handle: Handle<OverviewProps>) {
             {' '}context window. Every metric below links to its source.
           </p>
 
-          {/* v0.3.10 — health badge. Click → /risks. State derives
-              from severity counts; ok when no critical/high/secrets,
-              warn when stale/todos > 0, danger when any
-              critical/secret/broken finding exists. */}
+          {/* v0.3 — health badge. Click → /risks. Leads with the composite
+              grade (A–F · 0–100) when present, then the top deductions. Tone
+              comes from the shared healthTone() helper so it never disagrees
+              with the margin HealthGrade marque. Pre-v0.3 datasets (no letter)
+              fall back to the original severity-count summary below. */}
           {(() => {
+            const h = summary.health;
+            const tone = healthTone(h);
+            const toneStyle =
+              tone === 'danger' ? healthBadgeDanger : tone === 'warn' ? healthBadgeWarn : healthBadgeOk;
+            const verb = tone === 'danger' ? 'Act on Risks' : tone === 'warn' ? 'Open Risks' : 'View Risks';
+
+            if (h.grade && typeof h.score === 'number') {
+              // Reuse core's headline prose (single grammar source — memory
+              // pins it verbatim) by stripping the "{grade} · {score} — " head.
+              // Grade/score render strong from the structured fields; the factor
+              // tail renders muted. Take everything after the FIRST " — " so the
+              // clean tail ("clean — no blockers detected") survives intact.
+              const sep = h.headline.indexOf(' — ');
+              const tail = sep >= 0 ? h.headline.slice(sep + 3) : h.headline;
+              return (
+                <a
+                  href="/risks"
+                  mix={[healthBadge, toneStyle]}
+                  aria-label={`Health grade ${h.grade}, score ${h.score} of 100. ${tail}.`}
+                >
+                  <span aria-hidden="true" mix={healthBadgeBar} />
+                  <span mix={healthBadgeText}>
+                    <span mix={healthBadgeStrong}>{h.grade} · {h.score}</span>
+                    <span mix={css({ color: 'var(--fg-faint)' })}> — {tail}</span>
+                  </span>
+                  <span mix={healthBadgeArrow}>{verb} →</span>
+                </a>
+              );
+            }
+
+            // Fallback: pre-grade dataset. Original severity-count summary.
             const risks = data.risks;
             const counts = risks.reduce<Record<string, number>>((acc, r) => {
               acc[r.severity] = (acc[r.severity] ?? 0) + 1;
               return acc;
             }, {});
             const critical = counts.critical ?? 0;
-            const high = counts.high ?? 0;
-            const secrets = summary.health.secrets;
-            const broken = summary.health.broken;
-            const stale = summary.health.stale;
-            const todos = summary.health.todos;
-            const isDanger = critical > 0 || secrets > 0 || broken > 0;
-            const isWarn = !isDanger && (high > 0 || stale > 0);
-            const tone = isDanger ? healthBadgeDanger : isWarn ? healthBadgeWarn : healthBadgeOk;
-            const label = isDanger
-              ? `${critical + secrets + broken} critical · review now`
-              : isWarn
-              ? `${risks.length} ${risks.length === 1 ? 'finding' : 'findings'} · ${stale} stale · ${todos} TODOs · review when convenient`
-              : `0 findings · scanned clean`;
-            const verb = isDanger ? 'Act on Risks' : isWarn ? 'Open Risks' : 'View Risks';
+            const label =
+              tone === 'danger'
+                ? `${critical + h.secrets + h.broken} critical · review now`
+                : tone === 'warn'
+                ? `${risks.length} ${risks.length === 1 ? 'finding' : 'findings'} · ${h.stale} stale · ${h.todos} TODOs · review when convenient`
+                : `0 findings · scanned clean`;
             return (
-              <a href="/risks" mix={[healthBadge, tone]} aria-label={`Health: ${label}`}>
+              <a href="/risks" mix={[healthBadge, toneStyle]} aria-label={`Health: ${label}`}>
                 <span aria-hidden="true" mix={healthBadgeBar} />
                 <span mix={healthBadgeText}>
                   <span mix={healthBadgeStrong}>{label.split('·')[0]?.trim()}</span>
                   <span mix={css({ color: 'var(--fg-faint)' })}> · {label.split('·').slice(1).join('·').trim()}</span>
                 </span>
-                <span mix={healthBadgeArrow}>
-                  {verb} →
-                </span>
+                <span mix={healthBadgeArrow}>{verb} →</span>
               </a>
             );
           })()}
@@ -388,20 +412,7 @@ export function Overview(handle: Handle<OverviewProps>) {
               </ul>
             </FootnoteChip>
           )}
-          <FootnoteChip
-            label="Health"
-            tone={
-              summary.health.broken > 0 || summary.health.secrets > 0
-                ? 'danger'
-                : summary.health.todos > 0
-                ? 'warn'
-                : 'ok'
-            }
-          >
-            {summary.health.broken === 0 && summary.health.secrets === 0
-              ? 'Clean. No broken imports, no secrets in source.'
-              : `${summary.health.broken} broken · ${summary.health.secrets} secrets · ${summary.health.todos} todos`}
-          </FootnoteChip>
+          <HealthGrade health={summary.health} />
           {summary.description && (
             <FootnoteChip label="Intent">{summary.description}</FootnoteChip>
           )}

--- a/apps/ui-remix/src/ui/HealthGrade.tsx
+++ b/apps/ui-remix/src/ui/HealthGrade.tsx
@@ -1,0 +1,176 @@
+/**
+ * HealthGrade — the composite project-health marque for the margin column.
+ *
+ * The editorial signature of the Overview: a large serif letter grade
+ * (A–F) tinted by severity, the 0–100 score beside it, and a compact
+ * "ledger" of the top deductions (factor · count · −penalty, with a thin
+ * proportional bar). It answers not just "how healthy?" but "what's
+ * costing points?" — the evidence sitting in the margin beside the claim.
+ *
+ * Composes FootnoteChip for its chrome (left rule, kicker, hairline,
+ * padding) so the margin column's chips stay structurally identical; the
+ * grade/score/ledger render in the chip's body. Falls back to a plain
+ * count summary when the dataset predates the grade (pre-v0.3 baked
+ * artifacts carry only flat broken/stale/todos/secrets).
+ */
+import type { Handle, RemixNode } from 'remix/ui';
+import { css } from 'remix/ui';
+import { FootnoteChip } from './FootnoteChip.tsx';
+import { healthTone, HEALTH_TONE_COLOR } from '../lib/healthTone.ts';
+import type { Dataset } from '../lib/loadArtifacts.ts';
+
+interface HealthGradeProps {
+  health: Dataset['summary']['health'];
+}
+
+/* Grade + score on one baseline: serif letter as the focal marque, the
+   /100 score as a mono footing. Baseline-aligned so the big letter and
+   the small figure read as one unit, not two stacked stats. */
+const marque = css({
+  display: 'flex',
+  alignItems: 'baseline',
+  gap: 'var(--space-3)',
+  marginBottom: 'var(--space-3)',
+});
+
+const gradeLetter = css({
+  fontFamily: 'var(--font-display)',
+  fontSize: 'clamp(2.6rem, 7vw, 3.4rem)',
+  fontWeight: '600',
+  lineHeight: '0.9',
+  letterSpacing: '-0.02em',
+  color: 'var(--tone)',
+});
+
+const scoreFigure = css({
+  fontFamily: 'var(--font-mono)',
+  fontSize: 'var(--fs-13)',
+  fontVariantNumeric: 'tabular-nums',
+  color: 'var(--fg-muted)',
+  whiteSpace: 'nowrap',
+});
+
+const scoreUnit = css({
+  color: 'var(--fg-faint)',
+});
+
+const ledger = css({
+  listStyle: 'none',
+  margin: '0',
+  padding: '0',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 'var(--space-3)',
+});
+
+const ledgerRow = css({
+  display: 'grid',
+  gridTemplateColumns: 'minmax(0, 1fr) auto',
+  alignItems: 'baseline',
+  columnGap: 'var(--space-3)',
+  rowGap: 'var(--space-2)',
+});
+
+const ledgerLabel = css({
+  fontSize: 'var(--fs-12)',
+  color: 'var(--fg)',
+  minWidth: '0',
+});
+
+const ledgerValue = css({
+  fontFamily: 'var(--font-mono)',
+  fontSize: 'var(--fs-11)',
+  fontVariantNumeric: 'tabular-nums',
+  color: 'var(--fg-subtle)',
+  whiteSpace: 'nowrap',
+});
+
+const ledgerPenalty = css({
+  color: 'var(--tone)',
+});
+
+/* Thin deduction bar — width proportional to this factor's penalty
+   against the heaviest one. Editorial weight, not a chart: a 2px rule
+   tinted toward the tone. */
+const barTrack = css({
+  gridColumn: '1 / -1',
+  height: '2px',
+  background: 'var(--hairline)',
+  position: 'relative',
+  overflow: 'hidden',
+});
+
+const barFill = css({
+  position: 'absolute',
+  insetBlock: '0',
+  insetInlineStart: '0',
+  width: 'var(--w)',
+  background: 'color-mix(in oklab, var(--tone) 70%, transparent)',
+});
+
+const cleanNote = css({
+  color: 'var(--fg-muted)',
+});
+
+export function HealthGrade(handle: Handle<HealthGradeProps>): () => RemixNode {
+  return () => {
+    const h = handle.props.health;
+    const tone = healthTone(h);
+
+    // Pre-v0.3 dataset: no letter grade. Show the flat-count summary so
+    // older baked artifacts still render something honest.
+    if (!h.grade || typeof h.score !== 'number') {
+      return (
+        <FootnoteChip label="Health" tone={tone}>
+          {h.broken === 0 && h.secrets === 0
+            ? 'Clean. No broken imports, no secrets in source.'
+            : `${h.broken} broken · ${h.secrets} secrets · ${h.todos} todos`}
+        </FootnoteChip>
+      );
+    }
+
+    const factors = h.factors ?? [];
+    const maxPenalty = factors.reduce((m, f) => Math.max(m, f.penalty), 0) || 1;
+
+    return (
+      <FootnoteChip label="Health" tone={tone}>
+        {/* --tone scopes the grade letter + deduction bars to the severity
+            color without re-deriving it. */}
+        <div style={`--tone:${HEALTH_TONE_COLOR[tone]}`}>
+          <div
+            mix={marque}
+            role="img"
+            aria-label={`Health grade ${h.grade}, score ${h.score} out of 100`}
+          >
+            <span mix={gradeLetter}>{h.grade}</span>
+            <span mix={scoreFigure}>
+              {h.score}
+              <span mix={scoreUnit}>/100</span>
+            </span>
+          </div>
+          {factors.length > 0 ? (
+            <ul mix={ledger}>
+              {factors.map((f) => (
+                <li key={f.label} mix={ledgerRow}>
+                  <span mix={ledgerLabel}>{f.label}</span>
+                  <span mix={ledgerValue}>
+                    {f.count} <span mix={ledgerPenalty}>−{f.penalty}</span>
+                  </span>
+                  <span mix={barTrack}>
+                    <span
+                      aria-hidden="true"
+                      mix={barFill}
+                      style={`--w:${Math.round((f.penalty / maxPenalty) * 100)}%`}
+                    />
+                  </span>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <span mix={cleanNote}>No blockers detected. Nothing dragging the score down.</span>
+          )}
+        </div>
+      </FootnoteChip>
+    );
+  };
+}

--- a/packages/core/src/health.ts
+++ b/packages/core/src/health.ts
@@ -1,0 +1,102 @@
+/**
+ * Composite project-health grade — pure + deterministic.
+ *
+ * Replaces the old plain-count headline ("106 TODOs.") with a 0–100 score +
+ * letter grade. The score is weighted SECURITY/CORRECTNESS-FIRST: secrets,
+ * vulnerabilities, and broken imports are grade-killers; cycles/stale/oversized
+ * are moderate; TODO volume is a minor nudge — so a clean-but-TODO-heavy repo
+ * still grades well (the whole point of the rewrite).
+ *
+ * Reads ONLY fields already on the AgentArtifact — no file re-reads, no
+ * `Date.now()`/`Math.random()` (the old `stale` count called `Date.now()`,
+ * a purity smell; here `stale` derives from `file.status`, keeping analyze()
+ * byte-deterministic, INV1/INV2). Vulnerabilities are usually restored onto the
+ * agent AFTER analyze(), so callers that restore them (CLI/MCP) recompute health.
+ *
+ * Scoring — start at 100, subtract capped penalties, clamp [0,100]:
+ *   secrets exposed     −25 each   (cap 60)
+ *   known vulns         by severity (cap 50): critical 20 · high 12 · medium 5 · low/unknown 2
+ *   broken imports      −8 each    (cap 32)
+ *   import cycles       −3 each    (cap 18)
+ *   oversized files     −2 each    (cap 10)
+ *   stale files         −1 each    (cap 10)
+ *   TODOs               ⌊count/50⌋ (cap 6)   ← 106 TODOs ⇒ only −2
+ * Letter: A≥90 · B≥80 · C≥70 · D≥60 · else F.
+ */
+import type { AgentArtifact, HealthFactor, HealthHeadline } from '@factstack/spec';
+
+/** Points each vulnerability subtracts, by severity (before the category cap). */
+const VULN_WEIGHT: Record<string, number> = { critical: 20, high: 12, medium: 5, low: 2, unknown: 2, info: 0 };
+
+/** Singular form of each factor label, for grammatically-correct prose at
+ *  count === 1 ("1 secret exposed", not "1 secrets exposed"). The plural
+ *  label stays the stable id in `factors[]` for the ledger/columns; only the
+ *  headline + banner prose pluralize. Keyed by the canonical plural label. */
+const FACTOR_SINGULAR: Record<string, string> = {
+  'secrets exposed': 'secret exposed',
+  'known vulnerabilities': 'known vulnerability',
+  'broken imports': 'broken import',
+  'import cycles': 'import cycle',
+  'oversized files': 'oversized file',
+  'stale files': 'stale file',
+  TODOs: 'TODO',
+};
+
+/** "{count} {label}" with the label de-pluralized at count === 1. Pure. */
+function phrase(count: number, label: string): string {
+  return `${count} ${count === 1 ? FACTOR_SINGULAR[label] ?? label : label}`;
+}
+
+const clamp = (n: number, max: number): number => Math.min(Math.max(0, Math.round(n)), max);
+
+export function computeHealth(agent: AgentArtifact): HealthHeadline {
+  const risks = agent.risks ?? [];
+  const files = agent.files ?? [];
+  const vulns = agent.vulnerabilities ?? [];
+
+  // `broken` = distinct files with a broken-import / parse-error / read-error
+  // risk (unscanned-import excluded — the file builds fine). Mirrors the prior
+  // headline's definition so the structured count stays continuous.
+  const brokenFiles = new Set<string>();
+  for (const r of risks) {
+    if (r.rule === 'unscanned-import') continue;
+    if ((r.category === 'broken-import' || r.category === 'parse-error' || r.category === 'read-error') && r.file) {
+      brokenFiles.add(r.file);
+    }
+  }
+  const broken = brokenFiles.size;
+  const secrets = risks.filter((r) => r.category === 'secret').length;
+  const oversized = risks.filter((r) => r.category === 'large-file').length;
+  const stale = files.filter((f) => f.status === 'stale').length;
+  const todos = files.reduce((sum, f) => sum + (f.todos?.length ?? 0), 0);
+  const cycles = agent.graph?.cycles?.length ?? 0;
+  const vulnPenalty = vulns.reduce((sum, v) => sum + (VULN_WEIGHT[v.severity] ?? 2), 0);
+
+  const candidates: HealthFactor[] = [
+    { label: 'secrets exposed', count: secrets, penalty: clamp(secrets * 25, 60) },
+    { label: 'known vulnerabilities', count: vulns.length, penalty: clamp(vulnPenalty, 50) },
+    { label: 'broken imports', count: broken, penalty: clamp(broken * 8, 32) },
+    { label: 'import cycles', count: cycles, penalty: clamp(cycles * 3, 18) },
+    { label: 'oversized files', count: oversized, penalty: clamp(oversized * 2, 10) },
+    { label: 'stale files', count: stale, penalty: clamp(stale, 10) },
+    { label: 'TODOs', count: todos, penalty: clamp(Math.floor(todos / 50), 6) },
+  ];
+
+  const score = Math.max(0, 100 - candidates.reduce((sum, f) => sum + f.penalty, 0));
+  const grade: NonNullable<HealthHeadline['grade']> =
+    score >= 90 ? 'A' : score >= 80 ? 'B' : score >= 70 ? 'C' : score >= 60 ? 'D' : 'F';
+
+  // Top deductions first; ties broken by label (deterministic). Only factors
+  // that actually cost points appear.
+  const factors = candidates
+    .filter((f) => f.penalty > 0)
+    .sort((a, b) => b.penalty - a.penalty || (a.label < b.label ? -1 : 1))
+    .slice(0, 3);
+
+  const tail =
+    factors.length === 0
+      ? 'clean — no blockers detected'
+      : factors.map((f) => phrase(f.count, f.label)).join(', ');
+
+  return { broken, stale, todos, secrets, score, grade, factors, headline: `${grade} · ${score} — ${tail}` };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,6 +20,8 @@ import type {
   ProjectMetaSchema,
 } from '@factstack/spec';
 import { FACTS_SCHEMA_VERSION } from '@factstack/spec';
+import { computeHealth } from './health.js';
+export { computeHealth } from './health.js';
 import { walk, type WalkedFile } from '@factstack/walker';
 import {
   applyRewrite,
@@ -740,28 +742,9 @@ export async function analyze(fs: FactsFS, opts: AnalyzeOptions = {}): Promise<A
   };
 
   // Build human artifact (dashboard).
-  // `broken` = number of distinct files that contributed at least one
-  // broken-import, parse-error, or read-error risk. Aggregating by file
-  // avoids double-counting when one file has multiple unresolved imports.
-  // `unscanned-import` rows are excluded: the target exists on disk, so
-  // the file builds fine — counting it as broken would overstate health.
-  const brokenFiles = new Set<string>();
-  for (const r of secrets) {
-    if (r.rule === 'unscanned-import') continue;
-    if ((r.category === 'broken-import' || r.category === 'parse-error' || r.category === 'read-error') && r.file) {
-      brokenFiles.add(r.file);
-    }
-  }
-  const broken = brokenFiles.size;
-  const staleThreshold = 180 * 24 * 60 * 60 * 1000;
-  const now_ms = Date.now();
-  // "stale" is unchanged-in-over-6-months AND still has a TODO — signals
-  // rot rather than plain age. Files with no TODO are assumed intentional.
-  const stale = outlines.filter(
-    (o) => o.todos.length > 0 && o.lastModifiedMs && now_ms - o.lastModifiedMs > staleThreshold,
-  ).length;
-  const todoCount = allTodos.reduce((s, x) => s + x.entries.length, 0);
-
+  // Project-health grade (0–100 score + letter + top factors) is computed by
+  // the pure computeHealth(agent) below — security/correctness-first, derived
+  // entirely from the assembled artifact (no Date.now(); INV1/INV2).
   const human: HumanArtifact = {
     $schema: 'https://factstack.dev/schema/human.v1.json',
     factsVersion: FACTS_SCHEMA_VERSION,
@@ -780,22 +763,7 @@ export async function analyze(fs: FactsFS, opts: AnalyzeOptions = {}): Promise<A
         handlerFile: '',
         description: null,
       })),
-      health: (() => {
-        /* Single source of truth for the secret count. The `secrets`
-           variable is actually the FULL risks array (license, todo, etc.
-           all live in it), so the headline must use the SAME filtered
-           count the structured field reports — not `secrets.length`,
-           which is the total risk count and produced the "1 secret
-           exposed" false flag when the only risk was a missing license. */
-        const secretCount = secrets.filter((r) => r.category === 'secret').length;
-        return {
-          broken,
-          stale,
-          todos: todoCount,
-          secrets: secretCount,
-          headline: buildHealthHeadline(broken, stale, todoCount, secretCount),
-        };
-      })(),
+      health: computeHealth(agent),
     },
     stack: languages.map((l) => ({
       name: l.label,
@@ -1163,16 +1131,6 @@ function findFirstSentence(line: string): string {
   }
   // No terminator found — return the line capped.
   return line.length > cap ? line.slice(0, cap - 1) + '…' : line.trim();
-}
-
-function buildHealthHeadline(broken: number, stale: number, todos: number, secrets: number): string {
-  const parts: string[] = [];
-  if (broken) parts.push(`${broken} broken file${broken === 1 ? '' : 's'}`);
-  if (stale) parts.push(`${stale} stale file${stale === 1 ? '' : 's'}`);
-  if (secrets) parts.push(`${secrets} secret${secrets === 1 ? '' : 's'} exposed`);
-  if (todos) parts.push(`${todos} TODO${todos === 1 ? '' : 's'}`);
-  if (parts.length === 0) return 'Clean — no blockers detected.';
-  return parts.join(', ') + '.';
 }
 
 function countPackages(outlines: FileOutline[]): number {

--- a/packages/core/test/health.test.ts
+++ b/packages/core/test/health.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, it } from 'vitest';
+import { computeHealth } from '../src/health.js';
+import type { AgentArtifact } from '@factstack/spec';
+
+/**
+ * Tests for `computeHealth(agent)` — the v0.3 composite project-health
+ * grade that replaced the plain "<N> TODOs." headline.
+ *
+ * Test philosophy:
+ *   - Penalties are pinned to exact numbers so a weight change is caught,
+ *     not silently absorbed. Every grade boundary (90/80/70/60) is tested
+ *     from both sides.
+ *   - Purity (INV1/INV2): the function reads only fields already on the
+ *     artifact. `stale` derives from `file.status`, never `Date.now()` —
+ *     so two calls on the same input are byte-identical.
+ *   - The prose headline must agree with the structured counts (the
+ *     RallyPro "fabricated secret" regression) and read grammatically
+ *     ("1 secret exposed", not "1 secrets exposed").
+ */
+
+// ── Fixture builders — only the fields computeHealth reads ─────────────
+
+function agentWith(parts: {
+  risks?: unknown[];
+  files?: unknown[];
+  vulnerabilities?: unknown[];
+  cycles?: unknown[];
+}): AgentArtifact {
+  return {
+    $schema: 'https://factstack.dev/schema/agent.v1.json',
+    factsVersion: '0.1.0',
+    generatedAt: '2026-06-01T00:00:00Z',
+    project: { name: 'demo', root: '/demo', languages: [], frameworks: [], entryPoints: [], monorepo: null },
+    files: parts.files ?? [],
+    graph: { nodes: [], edges: [], cycles: parts.cycles ?? [] },
+    routes: [],
+    scripts: {},
+    capabilities: [],
+    risks: parts.risks ?? [],
+    vulnerabilities: parts.vulnerabilities ?? [],
+    stats: { loc: 0, fileCount: 0, packageCount: 0, totalTokenCost: 0 },
+  } as unknown as AgentArtifact;
+}
+
+const risk = (category: string, opts: Record<string, unknown> = {}) => ({
+  severity: 'medium',
+  category,
+  rule: category,
+  message: 'm',
+  ...opts,
+});
+const secretRisk = (file: string) => risk('secret', { severity: 'high', file, rule: 'hardcoded-secret' });
+const brokenRisk = (file: string) => risk('broken-import', { file });
+const oversizedRisk = (file: string) => risk('large-file', { file });
+
+const staleFile = () => ({ status: 'stale', todos: [] });
+const okFile = (todoCount = 0) => ({
+  status: 'ok',
+  todos: Array.from({ length: todoCount }, (_, i) => ({ kind: 'TODO', line: i + 1, text: 'x' })),
+});
+const vuln = (severity: string) => ({
+  id: 'CVE-2024-0001',
+  severity,
+  ecosystem: 'npm',
+  package: 'p',
+  installedVersion: '1.0.0',
+  fixedVersion: null,
+  advisoryUrl: 'https://osv.dev/x',
+  lastChecked: 1,
+  manifestPath: 'package.json',
+});
+
+const make = (n: number, f: () => unknown) => Array.from({ length: n }, f);
+const cyclesOf = (n: number) => make(n, () => ['a', 'b']);
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+describe('computeHealth — pristine project', () => {
+  it('scores 100 / grade A with no factors and a clean headline', () => {
+    const h = computeHealth(agentWith({}));
+    expect(h.score).toBe(100);
+    expect(h.grade).toBe('A');
+    expect(h.factors).toEqual([]);
+    expect(h.headline).toBe('A · 100 — clean — no blockers detected');
+    expect(h.broken).toBe(0);
+    expect(h.stale).toBe(0);
+    expect(h.todos).toBe(0);
+    expect(h.secrets).toBe(0);
+  });
+});
+
+describe('computeHealth — grade boundaries', () => {
+  // Each row composes penalties to land on an exact score. Building blocks
+  // (before caps): secret −25 · cycle −3 · stale −1 · oversized −2 ·
+  // ⌊todos/50⌋ −1.
+  const cases: Array<{
+    name: string;
+    secrets?: number;
+    cycles?: number;
+    stale?: number;
+    todos?: number;
+    score: number;
+    grade: 'A' | 'B' | 'C' | 'D' | 'F';
+  }> = [
+    { name: 'A floor', stale: 10, score: 90, grade: 'A' },
+    { name: 'B ceiling', stale: 10, todos: 50, score: 89, grade: 'B' },
+    { name: 'B floor', cycles: 6, stale: 2, score: 80, grade: 'B' },
+    { name: 'C ceiling', cycles: 6, stale: 3, score: 79, grade: 'C' },
+    { name: 'C floor', secrets: 1, stale: 5, score: 70, grade: 'C' },
+    { name: 'D ceiling', secrets: 1, stale: 6, score: 69, grade: 'D' },
+    { name: 'D floor', secrets: 1, cycles: 5, score: 60, grade: 'D' },
+    { name: 'F', secrets: 1, cycles: 5, stale: 1, score: 59, grade: 'F' },
+  ];
+
+  for (const c of cases) {
+    it(`${c.name} → ${c.score} / ${c.grade}`, () => {
+      const risks = make(c.secrets ?? 0, () => 0).map((_, i) => secretRisk(`s${i}.ts`));
+      const files = [
+        ...make(c.stale ?? 0, staleFile),
+        ...(c.todos ? [okFile(c.todos)] : []),
+      ];
+      const h = computeHealth(agentWith({ risks, files, cycles: cyclesOf(c.cycles ?? 0) }));
+      expect(h.score).toBe(c.score);
+      expect(h.grade).toBe(c.grade);
+    });
+  }
+});
+
+describe('computeHealth — per-category caps', () => {
+  it('secrets cap at −60 (3 × 25 = 75 raw)', () => {
+    const risks = make(3, () => 0).map((_, i) => secretRisk(`s${i}.ts`));
+    expect(computeHealth(agentWith({ risks })).score).toBe(40);
+  });
+  it('vulnerabilities cap at −50 (10 critical = 200 raw)', () => {
+    expect(computeHealth(agentWith({ vulnerabilities: make(10, () => vuln('critical')) })).score).toBe(50);
+  });
+  it('broken imports cap at −32 (5 files × 8 = 40 raw)', () => {
+    const risks = make(5, () => 0).map((_, i) => brokenRisk(`b${i}.ts`));
+    expect(computeHealth(agentWith({ risks })).score).toBe(68);
+  });
+  it('import cycles cap at −18 (10 × 3 = 30 raw)', () => {
+    expect(computeHealth(agentWith({ cycles: cyclesOf(10) })).score).toBe(82);
+  });
+  it('oversized cap at −10, stale cap at −10, TODOs cap at −6', () => {
+    expect(computeHealth(agentWith({ risks: make(10, () => 0).map((_, i) => oversizedRisk(`o${i}.ts`)) })).score).toBe(90);
+    expect(computeHealth(agentWith({ files: make(20, staleFile) })).score).toBe(90);
+    expect(computeHealth(agentWith({ files: [okFile(500)] })).score).toBe(94);
+  });
+});
+
+describe('computeHealth — broken-import counting', () => {
+  it('counts DISTINCT files, not risk occurrences', () => {
+    const risks = [brokenRisk('a.ts'), brokenRisk('a.ts'), brokenRisk('b.ts')];
+    expect(computeHealth(agentWith({ risks })).broken).toBe(2);
+  });
+  it('excludes the unscanned-import rule (the file still builds)', () => {
+    const risks = [risk('broken-import', { file: 'a.ts', rule: 'unscanned-import' })];
+    const h = computeHealth(agentWith({ risks }));
+    expect(h.broken).toBe(0);
+    expect(h.score).toBe(100);
+  });
+  it('parse-error and read-error categories count as broken', () => {
+    const risks = [risk('parse-error', { file: 'a.ts' }), risk('read-error', { file: 'b.ts' })];
+    expect(computeHealth(agentWith({ risks })).broken).toBe(2);
+  });
+});
+
+describe('computeHealth — vulnerability severity weighting', () => {
+  const weights: Array<[string, number]> = [
+    ['critical', 80],
+    ['high', 88],
+    ['medium', 95],
+    ['low', 98],
+    ['unknown', 98],
+  ];
+  for (const [sev, score] of weights) {
+    it(`one ${sev} vuln → ${score}`, () => {
+      expect(computeHealth(agentWith({ vulnerabilities: [vuln(sev)] })).score).toBe(score);
+    });
+  }
+});
+
+describe('computeHealth — factor ledger', () => {
+  it('keeps the top 3 by penalty desc, drops zero-penalty factors', () => {
+    const risks = [secretRisk('s.ts'), brokenRisk('b.ts')];
+    const h = computeHealth(
+      agentWith({ risks, files: [...make(1, staleFile), okFile(50)], cycles: cyclesOf(6) }),
+    );
+    // penalties: secrets 25, cycles 18, broken 8, stale 1, todos 1 → top 3
+    expect(h.factors!.map((f) => f.label)).toEqual(['secrets exposed', 'import cycles', 'broken imports']);
+    expect(h.factors!.map((f) => f.penalty)).toEqual([25, 18, 8]);
+  });
+
+  it('breaks penalty ties by label ascending (deterministic)', () => {
+    // broken 1 file (8) and oversized 4 (8) tie; 'broken imports' < 'oversized files'.
+    const risks = [brokenRisk('b.ts'), ...make(4, () => 0).map((_, i) => oversizedRisk(`o${i}.ts`)), ...make(1, staleFile).map(() => secretRisk('x'))];
+    const h = computeHealth(agentWith({ risks, files: [staleFile()] }));
+    const tied = h.factors!.filter((f) => f.penalty === 8).map((f) => f.label);
+    expect(tied).toEqual(['broken imports', 'oversized files']);
+  });
+});
+
+describe('computeHealth — headline prose', () => {
+  it('uses singular grammar at count 1 ("1 secret exposed")', () => {
+    const h = computeHealth(agentWith({ risks: [secretRisk('s.ts')] }));
+    expect(h.secrets).toBe(1);
+    expect(h.headline).toBe('C · 75 — 1 secret exposed');
+    expect(h.headline).not.toMatch(/1 secrets/);
+  });
+  it('uses plural at count > 1 and joins factors with commas', () => {
+    const risks = [secretRisk('a.ts'), secretRisk('b.ts')];
+    const h = computeHealth(agentWith({ risks, cycles: cyclesOf(2) }));
+    // 2 secrets = −50, 2 cycles = −6 → 44 → F. The headline shows factor
+    // COUNTS (2 secrets, 2 cycles), not penalties.
+    expect(h.headline).toBe('F · 44 — 2 secrets exposed, 2 import cycles');
+  });
+  it('never fabricates a secret from a non-secret risk (RallyPro regression)', () => {
+    const h = computeHealth(agentWith({ risks: [risk('license', { rule: 'missing-license' })] }));
+    expect(h.secrets).toBe(0);
+    expect(h.headline).not.toMatch(/secret/i);
+    expect(h.score).toBe(100); // license is not a health penalty
+  });
+});
+
+describe('computeHealth — purity & determinism (INV1/INV2)', () => {
+  it('derives stale from file.status, not the clock', () => {
+    const fresh = computeHealth(agentWith({ files: [okFile(), okFile()] }));
+    expect(fresh.stale).toBe(0);
+    const stale = computeHealth(agentWith({ files: [staleFile(), okFile()] }));
+    expect(stale.stale).toBe(1);
+  });
+  it('is a pure function — identical input yields byte-identical output', () => {
+    const build = () => agentWith({ risks: [secretRisk('s.ts'), brokenRisk('b.ts')], files: [staleFile(), okFile(120)], cycles: cyclesOf(4) });
+    expect(JSON.stringify(computeHealth(build()))).toBe(JSON.stringify(computeHealth(build())));
+  });
+  it('tolerates an agent with no vulnerabilities field (pre-v0.6 artifact)', () => {
+    const bare = agentWith({});
+    delete (bare as { vulnerabilities?: unknown }).vulnerabilities;
+    expect(() => computeHealth(bare)).not.toThrow();
+    expect(computeHealth(bare).score).toBe(100);
+  });
+});

--- a/packages/emit-browser/src/write.ts
+++ b/packages/emit-browser/src/write.ts
@@ -58,6 +58,9 @@ export interface BrowserWriteResult {
   humanName: string;
   jsonlName: string | null;
   packName: string;
+  /** F8 — `agent.diff.pack` when a prior master was found + the diff
+   *  emitted; null on the first save or an unusable prior pack. */
+  diffName: string | null;
   snapshotName: string | null;
   memoryName: string | null;
   bytesWritten: number;
@@ -76,6 +79,19 @@ export async function writeBrowserArtifacts(
   const isMinimal = opts.profile === 'minimal';
   const writeSnapshot = opts.writeSnapshot ?? !isMinimal;
 
+  /* F8 — read the prior master before this overwrites it so the
+     orchestrator can emit the `agent.diff.pack` sidecar. Mirrors
+     readBrowserSnapshots' FSA walk: absent (.facts or agent.pack missing,
+     i.e. first save) or any error → undefined → no diff this run. */
+  let prevPackBody: string | undefined;
+  try {
+    const factsDir = await opts.root.getDirectoryHandle('.facts');
+    const packHandle = await factsDir.getFileHandle('agent.pack');
+    prevPackBody = await (await packHandle.getFile()).text();
+  } catch {
+    prevPackBody = undefined;
+  }
+
   const result = await writeArtifactsTo(writer, opts.agent, opts.human, {
     /* Conditional-spread because exactOptionalPropertyTypes rejects
        `{ key: undefined }`. */
@@ -84,12 +100,14 @@ export async function writeBrowserArtifacts(
     writeSnapshot,
     ...(opts.snapshotRetention !== undefined && { snapshotRetention: opts.snapshotRetention }),
     ...(opts.memoryBody !== undefined && { memoryBody: opts.memoryBody }),
+    ...(prevPackBody !== undefined && { prevPackBody }),
   });
 
   return {
     agentName: result.agentName,
     humanName: result.humanName,
     packName: result.packName,
+    diffName: result.diffName,
     jsonlName: result.jsonlName,
     memoryName: result.memoryName,
     snapshotName: result.snapshotName,

--- a/packages/emit/src/orchestrator.ts
+++ b/packages/emit/src/orchestrator.ts
@@ -22,6 +22,7 @@
 
 import type { AgentArtifact, FileWriter, HumanArtifact } from '@factstack/spec';
 import { AgentArtifactSchema, HumanArtifactSchema } from '@factstack/spec';
+import { computeDiff, decode, encodeIncremental, type PackHeader } from '@factstack/factspack';
 import { encodeAgentPack } from './pack.js';
 
 /**
@@ -73,6 +74,16 @@ export interface WriteArtifactsToOptions {
    * source-agnostic. When omitted or empty, no MEMORY.md is written.
    */
   memoryBody?: string;
+  /**
+   * F8 — the PREVIOUS `agent.pack` body, pre-read by the caller (the
+   * shims read it before this overwrites the file). When present and
+   * decodable, we additionally emit `agent.diff.pack`: the row-level
+   * delta from that master to this one, so a consumer holding the prior
+   * master applies a small diff instead of re-reading the whole pack.
+   * Omit it (or pass a body we can't use) and only the full master is
+   * written — the sidecar is purely additive and best-effort.
+   */
+  prevPackBody?: string;
 }
 
 export interface WriteArtifactsResult {
@@ -82,6 +93,9 @@ export interface WriteArtifactsResult {
   humanName: 'human.json';
   /** Always written: `agent.pack`. */
   packName: 'agent.pack';
+  /** F8 — `agent.diff.pack` when a usable `prevPackBody` was supplied and
+   *  the diff emitted; null otherwise (cold run, or an unusable prev). */
+  diffName: 'agent.diff.pack' | null;
   /** `agent.jsonl`, or null when streamable: false / minimal profile. */
   jsonlName: string | null;
   /** `MEMORY.md`, or null when memoryBody is omitted/empty. */
@@ -141,6 +155,48 @@ export async function writeArtifactsTo(
   bytes += await writer.writeText('human.json', humanBody);
   bytes += await writer.writeText('agent.pack', packBody);
 
+  /* F8 — incremental diff sidecar. When the caller supplies the previous
+     master, emit `agent.diff.pack`: the row-level delta from it to this
+     pack (encodeIncremental(computeDiff(prev, next))). It's a depth-1
+     accelerator — always the diff vs the immediately preceding master, not
+     a growing chain — so a consumer holding the prior master applies one
+     small diff instead of re-reading the whole pack. The full `agent.pack`
+     master above is untouched; the sidecar is purely additive.
+
+     Best-effort by design: any failure (a corrupt / pre-v0.2 / truncated
+     prev, a schema drift, a duplicate PK) skips the diff and leaves the
+     master as the source of truth. The emit step must never fail because
+     the accelerator couldn't build. The diff header's producer/schema/
+     snapshotId come from re-decoding the master we just wrote, so the
+     sidecar's identity can never drift from the pack it describes. */
+  let diffName: 'agent.diff.pack' | null = null;
+  if (options.prevPackBody) {
+    try {
+      const prev = decode(options.prevPackBody); // strict: throws on corrupt/legacy/truncated
+      const next = decode(packBody);
+      // Only diff a verifiable, same-schema master: the trailer sha anchors
+      // the chain (the consumer verifies it before applying), and a schema
+      // mismatch (e.g. an agent-v3 pack on disk) makes the rows incomparable.
+      if (prev.trailer && prev.header.schema === next.header.schema) {
+        const header: PackHeader = {
+          producer: next.header.producer,
+          schema: next.header.schema,
+          snapshotId: next.header.snapshotId,
+          rowCount: 0, // spec §7 diff sentinel — encodeIncremental enforces 0 here (not a placeholder)
+          seq: (prev.header.seq ?? 1) + 1,
+          parent: prev.trailer.sha256, // 12-hex of the master this diff applies onto
+          kind: 'diff',
+          ...(next.header.generated !== undefined && { generated: next.header.generated }),
+        };
+        const diffBody = encodeIncremental({ header, tables: computeDiff(prev, next) });
+        bytes += await writer.writeText('agent.diff.pack', diffBody);
+        diffName = 'agent.diff.pack';
+      }
+    } catch {
+      /* accelerator failed — master is still authoritative, carry on */
+    }
+  }
+
   /* agent.jsonl: streamable per-file. Profile sets the default
      (legacy on, minimal off); an explicit `streamable` still wins. */
   let jsonlName: string | null = null;
@@ -158,15 +214,12 @@ export async function writeArtifactsTo(
     memoryName = 'MEMORY.md';
   }
 
-  /* Snapshot: History-tab trend data. The profile sets the default
-     (legacy keeps the caller's prior default of false; minimal forces
-     off), but an explicit `writeSnapshot` still wins so the CLI's
-     `analyze` (which opts in) and the browser (which defaults on) keep
-     their behavior in legacy mode. In minimal, snapshots are off
-     unless the caller explicitly re-enables them. */
-  const snapshotDefault = isMinimal ? false : (options.writeSnapshot ?? false);
+  /* Snapshot: History-tab trend data, off unless the caller opts in.
+     Callers that want it on own that default explicitly — the browser
+     shim passes `writeSnapshot: !isMinimal` and the CLI's `analyze`
+     opts in — so the orchestrator needs no profile-based fallback. */
   let snapshotName: string | null = null;
-  if (options.writeSnapshot ?? snapshotDefault) {
+  if (options.writeSnapshot ?? false) {
     snapshotName = await writeSnapshotFile(writer, agent, human);
     if (snapshotName) {
       // Account for the snapshot bytes — writeText returns them but
@@ -187,6 +240,7 @@ export async function writeArtifactsTo(
     agentName,
     humanName: 'human.json',
     packName: 'agent.pack',
+    diffName,
     jsonlName,
     memoryName,
     snapshotName,

--- a/packages/emit/src/viz.ts
+++ b/packages/emit/src/viz.ts
@@ -72,7 +72,10 @@ export interface VizArtifact {
     oneLiner: string;
     description: string;
     capabilities: Array<{ icon: string; head: string; sub: string }>;
-    health: { broken: number; stale: number; todos: number; secrets: number };
+    /** Full composite health (v0.3): flat counts + headline + grade/score/
+     *  factors. Mirrors the spec so the in-browser FSA-scan Overview shows the
+     *  same grade as the CLI-baked dashboard (INV7 browser parity). */
+    health: HumanArtifact['summary']['health'];
   };
   stats: { files: number; loc: number; size: number; gzip: number; tokens: number };
   tree: VizTreeNode;
@@ -283,12 +286,9 @@ export function humanToViz(agent: AgentArtifact, human: HumanArtifact): VizArtif
       // hidden in the Overview render.
       description: human.summary.intent || '',
       capabilities,
-      health: {
-        broken: human.summary.health.broken,
-        stale: human.summary.health.stale,
-        todos: human.summary.health.todos,
-        secrets: human.summary.health.secrets,
-      },
+      // Carry the whole health object — headline + grade/score/factors
+      // included — so the browser-scan dashboard grades identically (INV7).
+      health: { ...human.summary.health },
     },
     stats: {
       files: agent.stats.fileCount,

--- a/packages/emit/src/write.ts
+++ b/packages/emit/src/write.ts
@@ -71,11 +71,19 @@ export async function writeArtifacts(opts: WriteOptions): Promise<{
   humanPath: string;
   jsonlPath: string | null;
   packPath: string;
+  diffPath: string | null;
   snapshotPath: string | null;
   memoryPath: string | null;
   bytesWritten: number;
 }> {
   const writer = new NodeFileWriter(opts.root);
+  /* F8 — read the prior master BEFORE writeArtifactsTo overwrites it, so the
+     orchestrator can emit an `agent.diff.pack` sidecar. Best-effort: absent
+     on the first run (no prior pack) or undefined on any read error → the
+     orchestrator simply writes no diff that run. */
+  const prevPackBody = await fs
+    .readFile(path.join(writer.artifactRoot, 'agent.pack'), 'utf8')
+    .catch(() => undefined);
   /* Conditional-spread because exactOptionalPropertyTypes rejects
      `{ key: undefined }` — the orchestrator's options must either
      have the key set to a real value or not have the key at all. */
@@ -85,6 +93,7 @@ export async function writeArtifacts(opts: WriteOptions): Promise<{
     ...(opts.writeSnapshot !== undefined && { writeSnapshot: opts.writeSnapshot }),
     ...(opts.snapshotRetention !== undefined && { snapshotRetention: opts.snapshotRetention }),
     ...(opts.memoryBody !== undefined && { memoryBody: opts.memoryBody }),
+    ...(prevPackBody !== undefined && { prevPackBody }),
   });
 
   /* Node-only extra: auto-add `.facts/` to .gitignore so artifacts
@@ -105,6 +114,7 @@ export async function writeArtifacts(opts: WriteOptions): Promise<{
     humanPath: path.join(root, result.humanName),
     jsonlPath: result.jsonlName ? path.join(root, result.jsonlName) : null,
     packPath: path.join(root, result.packName),
+    diffPath: result.diffName ? path.join(root, result.diffName) : null,
     memoryPath: result.memoryName ? path.join(root, result.memoryName) : null,
     snapshotPath: result.snapshotName
       ? path.join(root, 'snapshots', result.snapshotName)

--- a/packages/emit/test/diff-chain.bench.test.ts
+++ b/packages/emit/test/diff-chain.bench.test.ts
@@ -1,0 +1,114 @@
+/**
+ * F8 diff-chain benchmark (task #179) — the warm re-analyze win, as a
+ * deterministic assertion.
+ *
+ * Runs a representative repo through the REAL emit path twice: a cold run
+ * (full master, no prior pack) and a warm run (a handful of changed rows,
+ * with the prior master supplied). It then measures `agent.diff.pack`
+ * against `agent.pack` and asserts the diff is a small fraction of the
+ * master — the whole point of the feature: a consumer holding the master
+ * ingests a few hundred bytes instead of re-reading the whole pack.
+ *
+ * Doubling as a correctness check: the diff is applied back onto the prior
+ * master and must reconstruct the new master's tables (round-trip), so the
+ * "it's smaller" number can never come at the cost of "it's wrong".
+ *
+ * The numbers print to the test log so the benchmark is legible, not just
+ * a pass/fail. They are not asserted exactly (byte counts shift with the
+ * schema); the RATIO is what's pinned.
+ */
+import { describe, expect, it } from 'vitest';
+import { writeArtifactsTo } from '../src/orchestrator.js';
+import { MemoryFileWriter } from './helpers/memory-writer.js';
+import { applyChain, decode } from '@factstack/factspack';
+import type { AgentArtifact, HumanArtifact } from '@factstack/spec';
+
+function baseAgent(): AgentArtifact {
+  return {
+    $schema: 'https://factstack.dev/schema/agent.v1.json',
+    factsVersion: '0.1.0',
+    generatedAt: new Date().toISOString(),
+    project: { name: 'bench', root: '.', languages: [], frameworks: [], entryPoints: [], monorepo: null },
+    files: [],
+    graph: { nodes: [], edges: [], cycles: [] },
+    routes: [],
+    scripts: {},
+    capabilities: [],
+    risks: [],
+    stats: { loc: 0, fileCount: 0, packageCount: 0, totalTokenCost: 0 },
+  } as AgentArtifact;
+}
+
+function makeHuman(): HumanArtifact {
+  return {
+    $schema: 'https://factstack.dev/schema/human.v1.json',
+    factsVersion: '0.1.0',
+    generatedAt: new Date().toISOString(),
+    summary: { oneLiner: 'bench', intent: '', capabilities: [], entryPoints: [], health: { broken: 0, stale: 0, todos: 0, secrets: 0, headline: 'ok' } },
+    stack: [],
+    tree: { id: 'root', name: 'root', path: '.', kind: 'directory', language: null, loc: 0, tokenCost: 0, bundleSizeGzip: null, status: 'ok', children: [] },
+    graph: { nodes: [], edges: [], cycles: [] },
+    activity: [],
+    risks: [],
+    glossary: [],
+  } as HumanArtifact;
+}
+
+/** A repo whose pack has `n` risk rows — a realistic stand-in for a
+ *  few-hundred-finding analysis. The warm run adds a few more. */
+function agentWithRisks(n: number): AgentArtifact {
+  return {
+    ...baseAgent(),
+    risks: Array.from({ length: n }, (_, i) => ({
+      severity: 'low',
+      category: 'large-file',
+      rule: 'oversized',
+      message: `file src/module-${i}/component-${i}.ts exceeds the size budget`,
+      file: `src/module-${i}/component-${i}.ts`,
+      line: i + 1,
+    })),
+  } as AgentArtifact;
+}
+
+const bytes = (s: string) => new TextEncoder().encode(s).byteLength;
+
+describe('F8 diff-chain benchmark — warm re-analyze size win', () => {
+  it('a few-row change produces a diff that is a small fraction of the master', async () => {
+    const COLD = 250; // findings in the baseline analysis
+    const CHANGED = 5; // findings added on the warm re-analyze
+
+    // Cold run — full master, no prior pack.
+    const w1 = new MemoryFileWriter();
+    await writeArtifactsTo(w1, agentWithRisks(COLD), makeHuman());
+    const master = w1.get('agent.pack')!;
+
+    // Warm run — same repo plus CHANGED new findings, prior master supplied.
+    const w2 = new MemoryFileWriter();
+    const r = await writeArtifactsTo(w2, agentWithRisks(COLD + CHANGED), makeHuman(), { prevPackBody: master });
+    const diff = w2.get('agent.diff.pack')!;
+
+    const masterBytes = bytes(master);
+    const diffBytes = bytes(diff);
+    const ratio = diffBytes / masterBytes;
+    // eslint-disable-next-line no-console
+    console.log(
+      `[F8 bench] master=${masterBytes}B  diff=${diffBytes}B  ratio=${(ratio * 100).toFixed(1)}%  ` +
+        `(${COLD} findings, +${CHANGED} changed)`,
+    );
+
+    expect(r.diffName).toBe('agent.diff.pack');
+    // The win: the diff is well under a fifth of the master. In practice it's
+    // a couple percent; 20% is a deliberately loose guard against schema drift.
+    expect(diffBytes * 5).toBeLessThan(masterBytes);
+
+    // Correctness: the diff applies back onto the prior master to reproduce
+    // the new master's risks table — small AND right. Compare CONTENT as an
+    // order-independent set (applyChain doesn't promise the master's row
+    // order), so the size win can never come at the cost of wrong data.
+    const rebuilt = applyChain(decode(master), [decode(diff)]);
+    const newMasterRisks = decode(w2.get('agent.pack')!).tables.get('risks')!;
+    expect(newMasterRisks.rows.length).toBe(COLD + CHANGED);
+    const asSet = (rows: readonly (readonly (string | null)[])[]) => rows.map((r) => JSON.stringify(r)).sort();
+    expect(asSet(rebuilt.get('risks')!.rows)).toEqual(asSet(newMasterRisks.rows));
+  });
+});

--- a/packages/emit/test/orchestrator.test.ts
+++ b/packages/emit/test/orchestrator.test.ts
@@ -15,6 +15,7 @@
 import { describe, expect, it, beforeEach } from 'vitest';
 import { writeArtifactsTo } from '../src/orchestrator.js';
 import { MemoryFileWriter } from './helpers/memory-writer.js';
+import { applyChain, decode, encode } from '@factstack/factspack';
 import type { AgentArtifact, HumanArtifact } from '@factstack/spec';
 
 let writer: MemoryFileWriter;
@@ -91,6 +92,69 @@ describe('writeArtifactsTo — basic write', () => {
     // Invalid: stats.loc must be non-negative integer
     (bad as any).stats.loc = -1;
     await expect(writeArtifactsTo(writer, bad, makeHuman())).rejects.toThrow();
+  });
+});
+
+describe('writeArtifactsTo — F8 diff sidecar', () => {
+  /** A risk row is the simplest thing that changes a pack table between
+   *  runs (the risks table gains a row). Avoids needing a full File shape. */
+  function agentWithRisk(): AgentArtifact {
+    return {
+      ...makeAgent(),
+      risks: [{ severity: 'low', category: 'large-file', rule: 'big-file', message: 'oversized', file: 'src/big.ts' }],
+    } as AgentArtifact;
+  }
+
+  it('writes no diff on a cold run (no prevPackBody)', async () => {
+    const r = await writeArtifactsTo(writer, makeAgent(), makeHuman());
+    expect(r.diffName).toBeNull();
+    expect(writer.has('agent.diff.pack')).toBe(false);
+  });
+
+  it('emits agent.diff.pack on a warm run, and the diff applies back to the new master', async () => {
+    // Cold run captures the prior master.
+    await writeArtifactsTo(writer, makeAgent(), makeHuman());
+    const master = writer.get('agent.pack')!;
+
+    // Warm run: one new risk row vs the master, with the prior pack supplied.
+    const w2 = new MemoryFileWriter();
+    const r = await writeArtifactsTo(w2, agentWithRisk(), makeHuman(), { prevPackBody: master });
+
+    expect(r.diffName).toBe('agent.diff.pack');
+    expect(w2.has('agent.diff.pack')).toBe(true);
+
+    const diff = decode(w2.get('agent.diff.pack')!);
+    expect(diff.header.kind).toBe('diff');
+    expect(diff.header.seq).toBe(2);
+    expect(diff.header.parent).toBe(decode(master).trailer!.sha256);
+
+    // Applying the diff onto the prior master reconstructs the new master's
+    // risks table (the chain round-trips through the real emit path). Assert
+    // row CONTENT, not just the count — a count-only check would pass on a
+    // corrupted-but-right-length diff.
+    const rebuilt = applyChain(decode(master), [diff]);
+    const newMasterRisks = decode(w2.get('agent.pack')!).tables.get('risks')!;
+    expect(newMasterRisks.rows.length).toBe(1); // sanity: the master really changed
+    expect(rebuilt.get('risks')!.rows).toEqual(newMasterRisks.rows);
+  });
+
+  it('skips the diff (no throw) when prevPackBody is corrupt — master stays authoritative', async () => {
+    const r = await writeArtifactsTo(writer, makeAgent(), makeHuman(), { prevPackBody: 'not a pack at all' });
+    expect(r.diffName).toBeNull();
+    expect(writer.has('agent.diff.pack')).toBe(false);
+    expect(writer.has('agent.pack')).toBe(true);
+  });
+
+  it('skips the diff when the previous pack has a different schema', async () => {
+    // A valid v0.2 master stamped under an OLD schema name (agent-v3): it
+    // decodes fine, but the schema guard must refuse to diff across it.
+    const oldSchemaPack = encode({
+      header: { producer: 'factstack/0.0.0', schema: 'agent-v3', snapshotId: 'old', rowCount: null, seq: 1, parent: '-', kind: 'master', generated: 'old' },
+      tables: [{ name: 'files', columns: [{ name: 'path' }], rows: [['a.ts']] }],
+    });
+    const r = await writeArtifactsTo(writer, makeAgent(), makeHuman(), { prevPackBody: oldSchemaPack });
+    expect(r.diffName).toBeNull();
+    expect(writer.has('agent.diff.pack')).toBe(false);
   });
 });
 

--- a/packages/spec/src/human.ts
+++ b/packages/spec/src/human.ts
@@ -57,13 +57,32 @@ export const ActivityEntrySchema = z.object({
   authorCount: z.number().int().nonnegative(),
 });
 
+/** One signal that pushed the health score below 100, e.g. {label:"import
+ *  cycles", count:9, penalty:18}. Largest-penalty factors lead the headline. */
+export const HealthFactorSchema = z.object({
+  label: z.string(),
+  count: z.number().int().nonnegative(),
+  penalty: z.number().int().nonnegative(),
+});
+export type HealthFactor = z.infer<typeof HealthFactorSchema>;
+
 export const HealthHeadlineSchema = z.object({
   broken: z.number().int().nonnegative(),
   todos: z.number().int().nonnegative(),
   secrets: z.number().int().nonnegative(),
   stale: z.number().int().nonnegative(),
   headline: z.string(),
+  /** v0.3 — composite project-health grade. `score` is 0–100 (100 = pristine),
+   *  `grade` its letter (A≥90, B≥80, C≥70, D≥60, else F), computed
+   *  security/correctness-first so cosmetic signals (TODOs, stale) can't tank an
+   *  otherwise-clean repo. `factors` holds the top deductions for the headline +
+   *  dashboard. Optional/defaulted for backward-compat with pre-v0.3 artifacts
+   *  (INV4); FACTS_SCHEMA_VERSION stays 0.1.0. */
+  score: z.number().int().min(0).max(100).optional(),
+  grade: z.enum(['A', 'B', 'C', 'D', 'F']).optional(),
+  factors: z.array(HealthFactorSchema).optional(),
 });
+export type HealthHeadline = z.infer<typeof HealthHeadlineSchema>;
 
 export const SummarySchema = z.object({
   oneLiner: z.string(),

--- a/packages/spec/src/mcp.ts
+++ b/packages/spec/src/mcp.ts
@@ -268,6 +268,7 @@ export const MCP_TOOL_NAMES = [
   'review_change',
   'count_tokens',
   'get_context',
+  'sync_pack',
 ] as const;
 
 /** Union of every tool name the FACTS MCP server ships. */
@@ -298,6 +299,7 @@ export const MCP_TOOL = {
   review_change: 'review_change',
   count_tokens: 'count_tokens',
   get_context: 'get_context',
+  sync_pack: 'sync_pack',
 } as const satisfies { [K in ShippedMcpToolName]: K };
 
 /** F7 — input for the `count_tokens` tool: count a project file's tokens (by
@@ -325,6 +327,17 @@ export const ContextInputSchema = z.object({
   maxHops: z.number().int().nonnegative().default(2),
 });
 export type ContextInput = z.infer<typeof ContextInputSchema>;
+
+/** F8 consumer — input for `sync_pack`. `have` is the 12-hex sha256 of the
+ *  `agent.pack` master the caller currently holds (read from the trailer line
+ *  of a pack a prior `sync_pack` returned). Omit it on the first fetch. When it
+ *  matches the previous master, the server returns just the small diff; when it
+ *  matches the current master, the server returns "current" (nothing changed);
+ *  otherwise it returns the full master. */
+export const SyncPackInputSchema = z.object({
+  have: z.string().optional(),
+});
+export type SyncPackInput = z.infer<typeof SyncPackInputSchema>;
 
 /* ─────────── (legacy) partial input-schema catalog ─────────── */
 


### PR DESCRIPTION
Two gated, independently-committed waves on top of `pack-v4-compare` (PR #3). Both passed the full commit gate (double-verify → 3-lens adversarial review + fixes → whole-app test → ≥400-point ELI5 audit).

## Wave 1 — Health rollup (`10b1a68`)
Replaces the dashboard's weak `"<N> TODOs."` headline with a composite, security/correctness-weighted grade (A–F · 0–100).

- **core** `computeHealth` (pure, deterministic): start 100, subtract capped weighted penalties (secrets −25, vulns by severity, broken imports −8, cycles −3, oversized −2, stale −1, TODOs ⌊n/50⌋). `stale` now derives from `file.status` (drops the old `Date.now()` → INV1/INV2 clean).
- **spec** optional `score`/`grade`/`factors` on `HealthHeadline` (additive, INV4; `FACTS_SCHEMA_VERSION` unchanged).
- **cli/mcp** re-grade at the 4 CVE-restore sites so vulnerabilities land in the grade.
- **emit** `humanToViz` carries the full health → browser parity (INV7).
- **ui** `HealthGrade` marque (composes `FootnoteChip`) + shared `healthTone` helper + grade-first lede banner.
- **tests** 30 new (grade boundaries, caps, factor ordering, pluralization, purity).

FACTS grades **itself A · 98** — live on the dashboard.

## Wave 2 — F8 diff-chain (`f5ce30f`)
When a prior `agent.pack` exists, `writeArtifactsTo` also emits `agent.diff.pack`: the row-level delta from that master to the new one, so a consumer holding the prior master applies a small diff instead of re-reading the whole pack. The master stays a full, self-contained pack; the diff is a best-effort, additive, depth-1 accelerator.

- **orchestrator** decode prev+next → `computeDiff` → `encodeIncremental`; gated on `prevPackBody`, try/catch + schema/trailer guards (skip → master authoritative); diff header reuses the decoded master's identity + the prev trailer sha256 as `parent`. `FileWriter` interface unchanged.
- **node + browser shims** pre-read the prior pack, thread `prevPackBody`, expose `diffPath`/`diffName`. INV7 parity (FSA read mirrors Node).
- **tests** cold / warm / corrupt / schema-mismatch + a benchmark (size win + round-trip).
- **docs** CONTEXT.md F8 diff-chain vocabulary.

**Benchmark (#179):** content-change diff is **2.2%** of the master; a real structural dogfood is **27.2%** (global PageRank importance ripples `nodeMetrics`). Honest finding — the win is large for content edits, modest for add/remove churn. `.facts` is gitignored, so the diff never enters VCS.

## Verification
- Typecheck **35/35**, full suite **36/36** (1759+ tests)
- Bundle caps green (Main JS 101.46/102 KB, Lazy 184.83/200 KB)
- Dogfood: both artifacts regenerate correctly; `agent.diff.pack` emits with a valid `kind=diff` header + trailer
- Deployed to Cloudflare Pages (`factstack.pages.dev`) and verified live (grade in served HTML, deep-link SPA fallback 200)

🤖 Generated with [Claude Code](https://claude.com/claude-code)